### PR TITLE
Don't sign in if already signed in

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,16 @@
 - name: Ensure MAS is installed.
   homebrew: name=mas state=present
 
+- name: Get MAS account status
+  shell: 'mas account'
+  register: mas_account_result
+  failed_when: mas_account_result.rc > 1
+  changed_when: false
+
 - name: Sign in to MAS when email and password are provided.
   shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}"'
   register: mas_signin_result
-  when: mas_email != '' and mas_password != ''
+  when: mas_account_result.rc == 1 and mas_email != '' and mas_password != ''
 
 - name: List installed MAS apps.
   command: mas list


### PR DESCRIPTION
When I set the `mas_email` and `mas_password` variables, I can't run the playbook more than once, because the sign in task fails with the following message:

```
TASK [geerlingguy.mas : Sign in to MAS when email and password are provided.] **
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "mas signin \"***\" \"***\"",
"delta": "0:00:00.022188", "end": "2017-01-22 14:39:26.318431", "failed": true,
"rc": 1, "start": "2017-01-22 14:39:26.296243", "stderr": "", 
"stdout": "Warning: Already signed in", "stdout_lines": ["Warning: Already signed in"], 
"warnings": []}
```

Checking the account status beforehand solved the issue for me, so I wanted to share it here.

`mas account` has an exit code of `0` when we're already signed in and `1` if we're not.

A "shorter" possibility would have been to add `failed_when: mas_signin_result > 1` to the sign in task, but I personally prefer checking first instead of "cleaning up" after something went not as expected.

:octocat: 