### PR TITLE
Allow signing in interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Available variables are listed below, along with default values (see `defaults/m
 
     mas_email: ""
     mas_password: ""
+    mas_sign_in_interactively: no
 
 The credentials for your Mac App Store account. The Apps you install should already be purchased by/registered to this account.
 
-If setting these variables statically (e.g. in an included vars file), you should encrypt the inventory using [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html). Otherwise you can use [`vars_prompt`](http://docs.ansible.com/ansible/playbooks_prompts.html) to prompt for the password at playbook runtime.
+If setting these variables statically (e.g. in an included vars file), you should encrypt the inventory using [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html). Otherwise you can toggle the `mas_sign_in_interactively` variable, or use [`vars_prompt`](http://docs.ansible.com/ansible/playbooks_prompts.html) to prompt for the password at playbook runtime.
 
 If you leave both blank, and don't prompt for them, the role assumes you've already signed in via other means (e.g. via GUI or `mas signin [email]`), and will not attempt to sign in again.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 mas_email: ""
 mas_password: ""
-mas_installed_app_ids: [] # Deprecated
+mas_sign_in_interactively: no
+mas_is_testing: no
+
 mas_installed_apps:
   - { id: 425264550, name: "Blackmagic Disk Speed Test (3.0)" }
   - { id: 411643860, name: "DaisyDisk (4.3.2)" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,16 +2,24 @@
 - name: Ensure MAS is installed.
   homebrew: name=mas state=present
 
-- name: Get MAS account status
-  shell: 'mas account'
-  register: mas_account_result
-  failed_when: mas_account_result.rc > 1
-  changed_when: false
+- include: status.yml
 
-- name: Sign in to MAS when email and password are provided.
-  shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}"'
-  register: mas_signin_result
-  when: mas_account_result.rc == 1 and mas_email != '' and mas_password != ''
+- name: Sign in interactively.
+  shell: mas signin "{{ mas_email }}" --dialog
+  when: not mas_is_signed_in and not mas_password and mas_sign_in_interactively and not mas_is_testing
+  failed_when: false
+
+- name: Sign in with email and password.
+  shell: mas signin "{{ mas_email }}" "{{ mas_password }}"
+  when: not mas_is_signed_in and mas_email and mas_password
+
+- include: status.yml
+  when: not mas_is_signed_in
+
+- name: Fail if still not signed in.
+  fail:
+    msg: "You must be signed into the Mac App Store to install apps"
+  when: not mas_is_signed_in and not mas_is_testing
 
 - name: List installed MAS apps.
   command: mas list

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Fail if still not signed in.
   fail:
-    msg: "You must be signed into the Mac App Store to install apps"
+    msg: "You must be signed into the Mac App Store to install apps."
   when: not mas_is_signed_in and not mas_is_testing
 
 - name: List installed MAS apps.

--- a/tasks/status.yml
+++ b/tasks/status.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Get account status.
+  shell: 'mas account'
+  register: mas_account_status
+  failed_when: false
+  always_run: yes
+  changed_when: false
+
+- name: Get signin status.
+  set_fact:
+    mas_is_signed_in: "{{ 'Not signed in' not in mas_account_status.stdout }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,7 @@
   vars:
     mas_installed_app_ids: []
     mas_installed_apps: []
+    mas_is_testing: yes
 
   roles:
     - geerlingguy.homebrew


### PR DESCRIPTION
I would like to propose the following changes:

- In addition to using `vars_prompt` in the playbook, enable the usage of the `--dialog` option of the mas CLI app by setting a new `mas_sign_in_interactively` variable to `yes`
- Store the account status (signed in or not) in a distinct variable/fact, instead of relying on `mas_account_result.rc` (I proposed this myself in #3, but now I find it rather gross ¯\\_(ツ)_/¯)
- Fail "gracefully" when the user is not signed in by using a readable message instead of the larger JSON blob generated when `mas install <...>` fails

There's now also a `mas_is_testing` variable so that the Travis-CI tests won't fail on the "graceful fail" step (I hope).

I would have liked to set `mas_sign_in_interactively: yes` by default, but this would have changed the behavior to existing playbooks when updating the role.

:octocat: 