### PR TITLE
Enhance playbook output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ If setting these variables statically (e.g. in an included vars file), you shoul
 
 If you leave both blank, and don't prompt for them, the role assumes you've already signed in via other means (e.g. via GUI or `mas signin [email]`), and will not attempt to sign in again.
 
-    mas_installed_app_ids:
-      - 425264550 # Blackmagic Disk Speed Test (3.0)
-      - 411643860 # DaisyDisk (4.3.2)
-      - 498486288 # Quick Resizer (1.9)
-      - 497799835 # Xcode (8.1)
+    mas_installed_apps:
+      - { id: 425264550, name: "Blackmagic Disk Speed Test (3.0)" }
+      - { id: 411643860, name: "DaisyDisk (4.3.2)" }
+      - { id: 498486288, name: "Quick Resizer (1.9)" }
+      - { id: 497799835, name: "Xcode (8.1)" }
 
-A list of apps to ensure are installed on the computer. You can get IDs for all your existing installed apps with `mas list`, and you can search for IDs with `mas search [App Name]`.
+A list of apps to ensure are installed on the computer. You can get IDs for all your existing installed apps with `mas list`, and you can search for IDs with `mas search [App Name]`. The `name` attribute is not authoritative and only used to provide better information in the playbook output.
 
     mas_upgrade_all_apps: no
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 mas_email: ""
 mas_password: ""
-
-mas_installed_app_ids:
-  - 425264550 # Blackmagic Disk Speed Test (3.0)
-  - 411643860 # DaisyDisk (4.3.2)
-  - 498486288 # Quick Resizer (1.9)
-  - 497799835 # Xcode (8.1)
+mas_installed_app_ids: [] # Deprecated
+mas_installed_apps:
+  - { id: 425264550, name: "Blackmagic Disk Speed Test (3.0)" }
+  - { id: 411643860, name: "DaisyDisk (4.3.2)" }
+  - { id: 498486288, name: "Quick Resizer (1.9)" }
+  - { id: 497799835, name: "Xcode (8.1)" }
 
 mas_upgrade_all_apps: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,9 @@
   changed_when: false
 
 - name: Ensure configured MAS apps are installed.
-  command: mas install "{{ item }}"
-  with_items: "{{ mas_installed_app_ids }}"
-  when: "'{{ item }}' not in mas_list.stdout"
+  command: mas install "{{ item.id|default(item) }}"
+  with_items: "{{ mas_installed_apps + mas_installed_app_ids }}"
+  when: "'{{ item.id|default(item) }}' not in mas_list.stdout"
 
 - name: Upgrade all apps (if configured).
   command: mas upgrade

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,7 @@
 
   vars:
     mas_installed_app_ids: []
+    mas_installed_apps: []
 
   roles:
     - geerlingguy.homebrew


### PR DESCRIPTION
At the moment, when executing the role, the playbook output only shows the MAS App IDs, which obscures the information which apps have been newly installed/were already installed.

With the changes proposed here, the user is encouraged to ensure a better output:

- Added the variable `mas_installed_apps`
- `mas_installed_app_ids` is still available and used, but marked as deprecated

Items in the array can be specified as previously, or with with a dict containing `id` and `name`, this means the following would all be equivalent:

```yaml
mas_installed_apps:
  # recommended
  - { id: 405399194, name: "Kindle" }
  # Not really useful, but possible
  - { id: 409789998 } # Twitter
  # Old style
  - 425424353 # The Unarchiver
```
and result in the following output (not exactly, my screenshot doesn't fit the definition above):

<img width="645" alt="output" src="https://cloud.githubusercontent.com/assets/67554/22523230/e073c696-e8be-11e6-89d9-96cafcfab7b6.png">

I hope I am not missing something crucial, but this should not affect existing users when they update the role.

:octocat: 