### PR TITLE
Add MAS CLI signin dialog (--dialog) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ If setting these variables statically (e.g. in an included vars file), you shoul
 
 If you leave both blank, and don't prompt for them, the role assumes you've already signed in via other means (e.g. via GUI or `mas signin [email]`), and will not attempt to sign in again.
 
+    mas_signin_dialog: no
+
+Fallback to the built-in Mac App Store dialog to complete sign in. If set to yes, you must specify the aforementioned `mas_email` variable which will be autofilled in the dialog and prompt you to enter your password, followed by the 2FA authorization code if enabled on the account.
+
     mas_installed_apps:
       - { id: 425264550, name: "Blackmagic Disk Speed Test (3.0)" }
       - { id: 411643860, name: "DaisyDisk (4.3.2)" }
@@ -42,10 +46,11 @@ Whether to run `mas upgrade`, which will upgrade all installed Mac App Store app
 
     - hosts: localhost
       vars:
-        mas_installed_app_ids:
-          - 497799835 # Xcode (8.1)
+        mas_installed_apps:
+          - { id: 497799835, name: "Xcode (8.1)" }
       roles:
         - geerlingguy.homebrew
+        - geerlingguy.mas
 
 See the [Mac Development Ansible Playbook](https://github.com/geerlingguy/mac-dev-playbook) for an example of this role's usage.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ mas_installed_apps:
   - { id: 497799835, name: "Xcode (8.1)" }
 
 mas_upgrade_all_apps: no
+mas_signin_dialog: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,12 @@
 - name: Sign in to MAS when email and password are provided.
   shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}"'
   register: mas_signin_result
-  when: mas_account_result.rc == 1 and mas_email != '' and mas_password != ''
+  when: mas_account_result.rc == 1 and mas_email != '' and mas_password != '' and not mas_signin_dialog
+
+- name: Sign in to MAS when email is provided, and complete password and 2FA using dialog.
+  shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}" --dialog'
+  register: mas_signin_result
+  when: mas_signin_dialog and mas_account_result.rc == 1 and mas_email != ''
 
 - name: List installed MAS apps.
   command: mas list


### PR DESCRIPTION
I've implemented support for the MAS CLI signin `--dialog` option by adding a new variable `mas_signin_dialog`.  By default it's disabled, so the existing role behavior is maintained, but when enabled the user must specify `mas_email`.

I've added this feature because if your Apple account has 2FA enabled and you try to login for the first time on a new device via the MAS CLI with `mas_email` and `mas_password`, the MAS CLI fails.

Fortunately, there are a couple of solutions to get MAS CLI to work with 2FA (See mas-cli/mas#36).
I think supporting the `--dialog` option is the better of the two solutions. This option allows specifying only your Apple ID and completing sign in via the actual MAS sign in dialog; it autofills your Apple ID/ email in the dialog, then you just type your password in and submit, and if you have 2FA enable it will then prompt for the auth code.

One notable advantage to falling back to the builtin dialog besides supporting 2FA, is Ansible never has to pass your plaintext password through the shell to MAS CLI. Even if you use vars_prompt to avoid putting a plaintext password in your playbook, I alarmingly discovered that your plaintext password gets written to stdout by Ansible when the task that performs the MAS CLI signin fails.

Let me know if you have any questions, thanks for creating this role, your various Ansible repos have been immensely useful.