### PR TITLE
Fix `when` statement syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Ensure configured MAS apps are installed.
   command: mas install "{{ item.id|default(item) }}"
   with_items: "{{ mas_installed_apps + mas_installed_app_ids }}"
-  when: "'{{ item.id|default(item) }}' not in mas_list.stdout"
+  when: item.id|default(item)|string not in mas_list.stdout 
 
 - name: Upgrade all apps (if configured).
   command: mas upgrade


### PR DESCRIPTION
`when` statements should not include jinja2 templating delimiters such as {{ }} or {% %}

Fixes #9 