### PR TITLE
Fix check mode and improve syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,12 +11,12 @@
 - name: Sign in to MAS when email and password are provided.
   shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}"'
   register: mas_signin_result
-  when: mas_account_result.rc == 1 and mas_email != '' and mas_password != '' and not mas_signin_dialog
+  when: not mas_account_result.skipped and mas_account_result.rc == 1 and mas_email != '' and mas_password != '' and not mas_signin_dialog
 
 - name: Sign in to MAS when email is provided, and complete password and 2FA using dialog.
   shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}" --dialog'
   register: mas_signin_result
-  when: mas_signin_dialog and mas_account_result.rc == 1 and mas_email != ''
+  when: not mas_account_result.skipped and mas_signin_dialog and mas_account_result.rc == 1 and mas_email != ''
 
 - name: List installed MAS apps.
   command: mas list

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,12 +11,20 @@
 - name: Sign in to MAS when email and password are provided.
   shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}"'
   register: mas_signin_result
-  when: not mas_account_result.skipped and mas_account_result.rc == 1 and mas_email != '' and mas_password != '' and not mas_signin_dialog
+  when: >
+    not mas_account_result.skipped and
+    not mas_signin_dialog and
+    mas_account_result.rc == 1 and
+    mas_email != '' and mas_password != ''
 
 - name: Sign in to MAS when email is provided, and complete password and 2FA using dialog.
   shell: 'mas signin "{{ mas_email }}" "{{ mas_password }}" --dialog'
   register: mas_signin_result
-  when: not mas_account_result.skipped and mas_signin_dialog and mas_account_result.rc == 1 and mas_email != ''
+  when: >
+    not mas_account_result.skipped and
+    mas_signin_dialog and
+    mas_account_result.rc == 1 and
+    mas_email != ''
 
 - name: List installed MAS apps.
   command: mas list


### PR DESCRIPTION
I ran into an issue when using check mode, because the `rc` key doesn't exists on return values of skipped tasks.
Apart from fixing this, I did some small syntax improvements.