### PR TITLE
Fix `mas account` check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Get MAS account status
   command: mas account
   register: mas_account_result
-  failed_when: mas_account_result.rc > 1
+  failed_when: mas_account_result.rc > 0
   changed_when: false
 
 - name: Sign in to MAS when email and password are provided.


### PR DESCRIPTION
`mas account` returns `1` if the user isn't signed in, but the current task checks for return codes *greater than* `1`. Check for codes greater than `0` instead to fail at correct times.