### PR TITLE
Add check_mode: no to Get mas account status task to support check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
   command: mas account
   register: mas_account_result
   failed_when: mas_account_result.rc > 1
+  check_mode: no
   changed_when: false
 
 - name: Sign in to MAS when email and password are provided.


### PR DESCRIPTION
Noticed I couldn't run check mode on this module. Added a check_mode: no statement to a task that makes no modifications and exists just to pull mas status.