### PR TITLE
Add ability to ensure specified mas apps are uninstalled

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Fallback to the built-in Mac App Store dialog to complete sign in. If set to yes
 
 A list of apps to ensure are installed on the computer. You can get IDs for all your existing installed apps with `mas list`, and you can search for IDs with `mas search [App Name]`. The `name` attribute is not authoritative and only used to provide better information in the playbook output.
 
+    mas_uninstalled_apps: []
+
+A list of apps to ensure are uninstalled on the computer. IDs can be determined using `mas list`.
+
     mas_upgrade_all_apps: false
 
 Whether to run `mas upgrade`, which will upgrade all installed Mac App Store apps.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ mas_installed_apps:
   - { id: 411643860, name: "DaisyDisk (4.3.2)" }
   - { id: 498486288, name: "Quick Resizer (1.9)" }
   - { id: 497799835, name: "Xcode (8.1)" }
+mas_uninstalled_apps: []
 
 mas_upgrade_all_apps: false
 mas_signin_dialog: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,12 @@
   check_mode: false
   changed_when: false
 
+- name: Ensure configured MAS apps are uninstalled.
+  become: yes
+  command: mas uninstall "{{ item.id }}"
+  with_items: "{{ mas_uninstalled_apps }}"
+  when: (item.id | string) in mas_list.stdout
+
 - name: Ensure configured MAS apps are installed.
   command: mas install "{{ item.id|default(item) }}"
   with_items: "{{ mas_installed_apps + mas_installed_app_ids }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,7 @@
   vars:
     mas_installed_app_ids: []
     mas_installed_apps: []
+    mas_uninstalled_apps: []
 
   roles:
     - geerlingguy.homebrew


### PR DESCRIPTION
I was looking to ensure specific apps were uninstalled (to aid in transitions etc) and noted the functionality was missing. As it is present for casks/packages in your homebrew I figured it would possibly be desirable here as well.

Unfortunately it does require using `become` as otherwise `mas uninstall` would be unable to delete the app.