### PR TITLE
Load list of MAS apps from CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A list of apps to ensure are installed on the computer. You can get IDs for all 
 
 The path to a CSV list file of desired apps that will be merged with the content of the `mas_installed_apps` variable.
 
-    mas list | sed 's/ /,/' > "./my-desired-mas-apps.cvs"
+    mas list | sed 's/ /,/' > "./my-desired-mas-apps.csv"
 
     # example content: id,name
     926036361,LastPass (4.4.0)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fallback to the built-in Mac App Store dialog to complete sign in. If set to yes
 
 A list of apps to ensure are installed on the computer. You can get IDs for all your existing installed apps with `mas list`, and you can search for IDs with `mas search [App Name]`. The `name` attribute is not authoritative and only used to provide better information in the playbook output.
 
-    mas_installed_apps_list_file: "./my-desired-mas-apps.cvs"
+    mas_installed_apps_list_file: "./my-desired-mas-apps.csv"
 
 
 The path to a CSV list file of desired apps that will be merged with the content of the `mas_installed_apps` variable.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ Fallback to the built-in Mac App Store dialog to complete sign in. If set to yes
 
 A list of apps to ensure are installed on the computer. You can get IDs for all your existing installed apps with `mas list`, and you can search for IDs with `mas search [App Name]`. The `name` attribute is not authoritative and only used to provide better information in the playbook output.
 
+    mas_installed_apps_list_file: "./my-desired-mas-apps.cvs"
+
+
+The path to a CSV list file of desired apps that will be merged with the content of the `mas_installed_apps` variable.
+
+    mas list | sed 's/ /,/' > "./my-desired-mas-apps.cvs"
+
+    # example content: id,name
+    926036361,LastPass (4.4.0)
+    1462114288,Grammarly for Safari (9.17)
+    1153157709,Speedtest (1.15)
+    418343177,Analog (2.0)
+
+The CSV file of the MAS apps currently installed in a system can be obtained with the above command.
+
     mas_upgrade_all_apps: false
 
 Whether to run `mas upgrade`, which will upgrade all installed Mac App Store apps.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,6 @@ mas_installed_apps:
   - { id: 411643860, name: "DaisyDisk (4.3.2)" }
   - { id: 498486288, name: "Quick Resizer (1.9)" }
   - { id: 497799835, name: "Xcode (8.1)" }
-
+mas_installed_apps_list_file: ""
 mas_upgrade_all_apps: false
 mas_signin_dialog: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,27 @@
     - mas_account_result.rc == 1
     - mas_email | bool
 
+- block:
+  - name: Read list of desired MAS apps from CSV file.
+    read_csv:
+      path: "{{ mas_installed_apps_list_file }}"
+      fieldnames: id,name
+      delimiter: ','
+    register: mas_desired_apps
+    ignore_errors: yes
+
+  - name: Merge the list of desired MAS apps.
+    set_fact: mas_installed_apps={{ mas_installed_apps|default([]) | union(mas_desired_apps.list) }}
+    when: mas_desired_apps is defined
+
+  - name: Remove duplicates of desired MAS apps.
+    set_fact:
+      mas_installed_apps: "{{ mas_installed_apps | unique | list }}"
+    ignore_errors: yes
+  # end block
+  when:  mas_installed_apps_list_file is defined and mas_installed_apps_list_file != ''
+  delegate_to: localhost
+
 - name: List installed MAS apps.
   command: mas list
   register: mas_list


### PR DESCRIPTION
The option `mas_installed_apps_list_file` loof for a local file (on the deployer's machine) to load a list of desired MAS apps.
This list will be merged to the content of `mas_installed_apps`.
The option `mas_installed_apps_list_file` is only optional if absent or left blank will be ignored.